### PR TITLE
Add on("select", cb)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ var Graph = require('p2p-graph')
 
 var graph = new Graph('.root')
 
+graph.on("select", function(id) {
+  console.log(id + " selected!")
+})
+
 // Add two peers
 graph.add({
   id: 'peer1',
@@ -112,6 +116,10 @@ Return an array of Nodes.
 ### graph.destroy()
 
 Destroys the graph and all the listeners related to it.
+
+### graph.on(event, cb)
+
+Sets callback for specified event. Currently only "select" event is supported which executed on select (argument is id of peer) or deselect (argument is false) peer in the graph.
 
 ## license
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ var Graph = require('p2p-graph')
 
 var graph = new Graph('.root')
 
-graph.on("select", function(id) {
-  console.log(id + " selected!")
+graph.on("select", function (id) {
+  console.log(id + ' selected!')
 })
 
 // Add two peers

--- a/index.js
+++ b/index.js
@@ -340,7 +340,16 @@ function TorrentGraph (root) {
     debug('remove $s', id)
     var index = getNodeIndex(id)
     if (index === -1) throw new Error('remove: node does not exist')
+
+    if ((focus !== false) && (focus.id === id)) {
+      focus = false
+      if (undefined !== onSelect) {
+        onSelect(false)
+      }
+    }
+
     model.nodes.splice(index, 1)
+
     update()
   }
 

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ function TorrentGraph (root) {
   var height = (window.innerWidth >= 900) ? 400 : 250
 
   var focus
+  var onSelect
 
   model.links.forEach(function (link) {
     var source = model.nodes[link.source]
@@ -174,6 +175,7 @@ function TorrentGraph (root) {
                     .style('stroke', null)
             })
             .on('click', function (d) {
+
               if (focus === d) {
                 force.charge(-200 * scale())
                         .linkDistance(100 * scale())
@@ -184,12 +186,18 @@ function TorrentGraph (root) {
                 link.style('opacity', 0.3)
 
                 focus = false
+                if (undefined !== onSelect) {
+                  onSelect(false)
+                }
 
                 return
               }
 
               focus = d
-
+              if (undefined !== onSelect) {
+                onSelect(d.id)
+              }
+ 
               node.style('opacity', function (o) {
                 o.active = connected(d, o)
                 return o.active ? 1 : 0.2
@@ -422,6 +430,12 @@ function TorrentGraph (root) {
     update()
   }
 
+  function on (event, cb) {
+    if (event === "select") {
+      onSelect = cb
+    }
+  }
+
   var resizeEventHandler = debounce(refresh, 500)
 
   window.addEventListener('resize', resizeEventHandler)
@@ -449,6 +463,7 @@ function TorrentGraph (root) {
     choke: choke,
     seed: seed,
     rate: rate,
+    on: on,
     destroy: destroy
   }
 }

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ function TorrentGraph (root) {
                 link.style('opacity', 0.3)
 
                 focus = false
-                if (undefined !== onSelect) {
+                if (onSelect !== undefined) {
                   onSelect(false)
                 }
 
@@ -193,7 +193,7 @@ function TorrentGraph (root) {
               }
 
               focus = d
-              if (undefined !== onSelect) {
+              if (onSelect !== undefined) {
                 onSelect(d.id)
               }
 

--- a/index.js
+++ b/index.js
@@ -175,7 +175,6 @@ function TorrentGraph (root) {
                     .style('stroke', null)
             })
             .on('click', function (d) {
-
               if (focus === d) {
                 force.charge(-200 * scale())
                         .linkDistance(100 * scale())
@@ -197,7 +196,7 @@ function TorrentGraph (root) {
               if (undefined !== onSelect) {
                 onSelect(d.id)
               }
- 
+
               node.style('opacity', function (o) {
                 o.active = connected(d, o)
                 return o.active ? 1 : 0.2
@@ -431,7 +430,7 @@ function TorrentGraph (root) {
   }
 
   function on (event, cb) {
-    if (event === "select") {
+    if (event === 'select') {
       onSelect = cb
     }
   }


### PR DESCRIPTION
Adding callback on peer selection change like
```    let graph = new window.P2PGraph('.p2pgraph')
    graph.on("select", function(id) {
      console.log(id + " selected!")
    })
```
as for me one callback is more logical than setting up separate on each node
resolves #10 in some way :)